### PR TITLE
fix(ci): usar credenciales de test y ajustar lint frontend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,28 +21,28 @@ jobs:
       mysql:
         image: mysql:8.4
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ci_root_password
           MYSQL_ROOT_HOST: "%"
-          MYSQL_DATABASE: ${{ secrets.DB_NAME }}
-          MYSQL_USER: ${{ secrets.DB_USER }}
-          MYSQL_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MYSQL_DATABASE: squarestruct_test
+          MYSQL_USER: ci_user
+          MYSQL_PASSWORD: ci_password
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -p${{ secrets.DB_PASSWORD }}"
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pci_root_password"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=20
 
     # Variables de entorno que el backend necesita para conectarse a MySQL y arrancar.
     env:
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USER: ci_user
+      DB_PASSWORD: ci_password
+      DB_NAME: squarestruct_test
       PORT: 3000
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_SECRET: ci_jwt_secret
       NODE_ENV: test
 
     # Todo lo que se ejecute aqui se hara dentro de backend/.
@@ -73,7 +73,7 @@ jobs:
       # Espera a que el servicio MySQL este listo antes de seguir.
       - name: Wait for MySQL
         run: |
-          until mysqladmin ping -h 127.0.0.1 -uroot -p${{ secrets.DB_PASSWORD }} --silent; do
+          until mysqladmin ping -h 127.0.0.1 -uroot -pci_root_password --silent; do
             echo "Waiting for MySQL..."
             sleep 2
           done
@@ -81,8 +81,9 @@ jobs:
       # Carga el esquema y los datos iniciales que usan los tests de integracion.
       - name: Load schema and seeds
         run: |
-          mysql -h 127.0.0.1 -P 3306 -u root -p${{ secrets.DB_PASSWORD }} ${{ secrets.DB_NAME }} < db/schema.sql
-          mysql -h 127.0.0.1 -P 3306 -u root -p${{ secrets.DB_PASSWORD }} ${{ secrets.DB_NAME }} < db/seeds.sql
+          mysql -h 127.0.0.1 -P 3306 -u root -pci_root_password squarestruct_test < db/schema.sql
+          mysql -h 127.0.0.1 -P 3306 -u root -pci_root_password squarestruct_test < db/seeds.sql
+
 
       # Instala las dependencias del backend desde backend/package.json.
       - name: Install backend dependencies

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,7 +14,10 @@ export default defineConfig([
       reactRefresh.configs.vite,
     ],
     languageOptions: {
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.vitest,
+      },
       parserOptions: { ecmaFeatures: { jsx: true } },
     },
   },


### PR DESCRIPTION
## Descripción

Corrige el workflow de GitHub Actions para que los tests de backend usen credenciales locales de prueba en lugar de `secrets` y ajusta la configuración de ESLint del frontend para reconocer los tests de Vitest.

El problema inicial venía de una confusión conceptual: los `secrets` se usan cuando el workflow necesita credenciales reales o sensibles, como despliegues, APIs externas o entornos privados. En este caso, GitHub Actions crea un servicio MySQL temporal dentro del propio runner para ejecutar los tests, por lo que no es necesario ocultar esas credenciales.

Después de corregir el backend, el job de frontend seguía fallando en el paso de lint porque ESLint no reconocía los globales de Vitest, como `test` y `expect`.

## Cambios realizados

- Sustituye `secrets.DB_*` por credenciales de test en el servicio MySQL.
- Configura las variables de entorno del backend con valores de CI.
- Sustituye `secrets.JWT_SECRET` por un valor de test.
- Actualiza el healthcheck de MySQL.
- Actualiza la carga de `schema.sql` y `seeds.sql` para usar la base temporal de test.
- Configura ESLint para reconocer los globales de Vitest en frontend.

## Motivo

Usar `secrets` para una base de datos temporal de CI añade una dependencia innecesaria de la configuración del repositorio. Las credenciales usadas en el workflow son valores falsos de CI, solo existen durante la ejecución del job y no dan acceso a ninguna base de datos real.

Además, los tests frontend usan funciones globales de Vitest. Sin configurar esos globals, ESLint interpreta `test` y `expect` como variables no definidas y bloquea el workflow antes del build.

## Issue relacionado

Relacionado con #12
