### PR TITLE
test(backend): añadir tests de productos y pedidos

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -407,7 +407,10 @@ Sirve para probar manualmente el flujo básico del MVP:
 Actualmente hay:
 
 - test unitario para `GET /api/health`;
-- test de integración para registro, login y perfil autenticado.
+- test de integracion para registro, login y perfil autenticado;
+- test de integracion para `GET /api/productos`;
+- test de integracion para rutas protegidas de pedidos con y sin token;
+- test de integracion para creacion de pedidos autenticada.
 
 Comandos:
 
@@ -416,6 +419,9 @@ npm test
 npm run test:unit
 npm run test:integration
 ```
+
+La suite cubre health, registro, login, perfil autenticado, listado de productos, rutas protegidas de pedidos con y sin token y creacion de pedidos autenticada.
+
 
 Los tests de integración necesitan que la base de datos esté disponible.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -404,13 +404,7 @@ Sirve para probar manualmente el flujo básico del MVP:
 
 ## Tests automatizados
 
-Actualmente hay:
-
-- test unitario para `GET /api/health`;
-- test de integracion para registro, login y perfil autenticado;
-- test de integracion para `GET /api/productos`;
-- test de integracion para rutas protegidas de pedidos con y sin token;
-- test de integracion para creacion de pedidos autenticada.
+Los tests del backend estan documentados en `tests/README.md`.
 
 Comandos:
 
@@ -419,11 +413,6 @@ npm test
 npm run test:unit
 npm run test:integration
 ```
-
-La suite cubre health, registro, login, perfil autenticado, listado de productos, rutas protegidas de pedidos con y sin token y creacion de pedidos autenticada.
-
-
-Los tests de integración necesitan que la base de datos esté disponible.
 
 ## Notas de desarrollo
 

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,0 +1,47 @@
+# Tests del backend
+
+Los tests del backend usan Jest y Supertest para validar endpoints de Express.
+
+## Comandos
+
+Desde la carpeta `backend/`:
+
+```bash
+npm test
+```
+
+Ejecuta todos los tests.
+
+```bash
+npm run test:unit
+```
+
+Ejecuta solo los tests unitarios.
+
+```bash
+npm run test:integration
+```
+
+Ejecuta solo los tests de integracion.
+
+## Requisitos para tests de integracion
+
+Los tests de integracion necesitan que MySQL este levantado y que el archivo `.env` apunte a una base de datos valida.
+
+En local se puede levantar la base de datos con:
+
+```bash
+docker compose -f docker/docker-compose-dev.yml up -d
+```
+
+## Cobertura actual
+
+Actualmente la suite cubre:
+
+- `GET /api/health`.
+- Registro y login de usuarios.
+- Perfil autenticado.
+- `GET /api/productos`.
+- Rutas de pedidos protegidas sin token.
+- Rutas de pedidos protegidas con token.
+- Creacion de pedidos autenticada.

--- a/backend/tests/integration/productos-pedidos.test.js
+++ b/backend/tests/integration/productos-pedidos.test.js
@@ -1,0 +1,82 @@
+import request from 'supertest';
+import app, { db } from '../../src/app.js';
+
+describe('Productos y pedidos', () => {
+  const email = `pedido${Date.now()}@mail.com`;
+  const password = '12345678';
+  let token;
+  let idProducto;
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  it('GET /api/productos debe devolver productos del catalogo', async () => {
+    const res = await request(app).get('/api/productos');
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0].idProducto).toBeDefined();
+    expect(res.body[0].nombre).toBeDefined();
+
+    idProducto = res.body[0].idProducto;
+  });
+
+  it('prepara un usuario autenticado para probar pedidos', async () => {
+    const registerRes = await request(app)
+      .post('/api/usuarios/register')
+      .send({
+        nombre: 'Pedido',
+        primerApellido: 'Test',
+        email,
+        contrasena: password
+      });
+
+    expect(registerRes.statusCode).toBe(201);
+
+    const loginRes = await request(app)
+      .post('/api/usuarios/login')
+      .send({ email, contrasena: password });
+
+    expect(loginRes.statusCode).toBe(200);
+    expect(loginRes.body.token).toBeDefined();
+    token = loginRes.body.token;
+  });
+
+  it('GET /api/pedidos debe rechazar peticiones sin token', async () => {
+    const res = await request(app).get('/api/pedidos');
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('GET /api/pedidos debe permitir peticiones con token', async () => {
+    const res = await request(app)
+      .get('/api/pedidos')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('POST /api/pedidos debe crear un pedido con token', async () => {
+    const res = await request(app)
+      .post('/api/pedidos')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        direccionEnvio: 'Calle Test 123, Madrid',
+        metodoPago: 'tarjeta',
+        productos: [
+          {
+            idProducto,
+            cantidad: 1
+          }
+        ]
+      });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.mensaje).toBe('Pedido creado correctamente');
+    expect(res.body.idPedido).toBeDefined();
+    expect(Number(res.body.total)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Descripción

Añade tests de integración para validar los endpoints principales de productos y pedidos en el backend.

La PR cubre el listado de productos, el acceso a rutas protegidas de pedidos con y sin token, y la creación de pedidos autenticada.

## Cambios realizados

- Añade test de integración para `GET /api/productos`.
- Añade flujo de registro y login para obtener un token JWT en los tests.
- Añade test para `GET /api/pedidos` sin token.
- Añade test para `GET /api/pedidos` con token.
- Añade test para `POST /api/pedidos` con token.
- Añade documentación específica de tests en `backend/tests/README.md`.
- Simplifica la sección de tests en `backend/README.md`.

## Validación

Ejecutado en local:

```bash
npm test
```

## Issue relacionada

Relacionado con #33