### PR TITLE
Feat (admin): Añadir vista detalle panel admin de usuarios.

### DIFF
--- a/backend/tests/integration/auth-perfil.test.js
+++ b/backend/tests/integration/auth-perfil.test.js
@@ -4,7 +4,10 @@ import app, { db } from '../../src/app.js';
 describe('Registro y login de usuario', () => {
   const email = `test${Date.now()}@mail.com`;
   const password = '12345678';
+  const adminEmail = 'admin@squarestruct.com';
+  const adminPassword = '123456';
   let token;
+  let adminToken;
 
   // Cerramos la conexión al final para que el proceso de Jest termine limpio.
   afterAll(async () => {
@@ -40,5 +43,45 @@ describe('Registro y login de usuario', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.usuario).toBeDefined();
     expect(res.body.usuario.email).toBe(email);
+  });
+
+  it('prepara un token de administrador para validar permisos', async () => {
+    const res = await request(app)
+      .post('/api/usuarios/login')
+      .send({ email: adminEmail, contrasena: adminPassword });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+    adminToken = res.body.token;
+  });
+
+  it('GET /api/usuarios debe rechazar usuarios sin rol admin', async () => {
+    const res = await request(app)
+      .get('/api/usuarios')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toBe('Acceso solo para administradores');
+  });
+
+  it('GET /api/usuarios debe permitir al administrador ver la lista', async () => {
+    const res = await request(app)
+      .get('/api/usuarios')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('GET /api/usuarios/:id debe devolver el detalle de un usuario', async () => {
+    const res = await request(app)
+      .get('/api/usuarios/1')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.idUsuario).toBeDefined();
+    expect(res.body.email).toBeDefined();
+    expect(res.body.rol).toBeDefined();
   });
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -49,6 +49,12 @@ function App() {
   const [cartPanelOpen, setCartPanelOpen] = useState(false)
   // Items guardados en el carrito (para demo)
   const [cartItems, setCartItems] = useState([])
+
+  /**
+   * Tabs de settings reservadas para administradores.
+   * La validacion vive aqui para que no dependa solo de ocultar botones.
+   */
+  const adminOnlySettingsTabs = new Set(['usuarios', 'facturacion'])
   
   /**
    * Actualiza el usuario autenticado (despuÃ©s de login exitoso).
@@ -84,7 +90,12 @@ function App() {
     }
 
     if (settingsTabByPage[nextPage]) {
-      setSettingsTab(settingsTabByPage[nextPage])
+      const requestedTab = settingsTabByPage[nextPage]
+      const nextTab = adminOnlySettingsTabs.has(requestedTab) && !isAdmin()
+        ? 'perfil'
+        : requestedTab
+
+      setSettingsTab(nextTab)
       setPage('settings')
       setSearchTerm('')
       setCatalogSection('')
@@ -228,11 +239,15 @@ function App() {
         return <Home onNavigate={handleNavigate} />
       }
 
+      const protectedTab = adminOnlySettingsTabs.has(settingsTab) && !isAdmin()
+        ? 'perfil'
+        : settingsTab
+
       return (
         <Settings
-          key={settingsTab}
+          key={protectedTab}
           user={user}
-          initialTab={settingsTab}
+          initialTab={protectedTab}
           onAuthExpired={handleUserLogout}
           isAdminUser={isAdmin()}
         />

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { getAllUsers, getProfile, logoutUser, updateUser } from '../services/authService'
+import { getAllUsers, getProfile, getUserById, logoutUser, updateUser } from '../services/authService'
 import '../styles/settings.css'
 
 const getRoleBadgeClass = (role) => {
@@ -49,6 +49,9 @@ function Settings({ user, initialTab, onAuthExpired, isAdminUser }) {
   const [editingUsuario, setEditingUsuario] = useState(null)
   const [nuevoRol, setNuevoRol] = useState('usuario')
   const [isEditLoading, setIsEditLoading] = useState(false)
+  const [selectedUsuario, setSelectedUsuario] = useState(null)
+  const [isDetailLoading, setIsDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState('')
 
   const tabs = useMemo(() => {
     if (isAdminUser) {
@@ -125,9 +128,38 @@ function Settings({ user, initialTab, onAuthExpired, isAdminUser }) {
     setNuevoRol(usuario.rol)
   }
 
+  /**
+   * Carga el detalle completo de un usuario y abre el modal.
+   * Primero mostramos los datos ya visibles en la tabla para que la interfaz
+   * responda al instante; después se refresca con la ficha completa desde API.
+   * @param {object} usuario - Usuario seleccionado en la tabla.
+   */
+  const handleViewClick = async (usuario) => {
+    setSelectedUsuario(usuario)
+    setDetailError('')
+    setIsDetailLoading(true)
+
+    try {
+      const detalle = await getUserById(usuario.idUsuario)
+      setSelectedUsuario(detalle)
+    } catch {
+      setDetailError('No se pudo cargar el detalle actualizado del usuario.')
+    } finally {
+      setIsDetailLoading(false)
+    }
+  }
+
   const handleCloseModal = () => {
     setEditingUsuario(null)
     setNuevoRol('usuario')
+  }
+
+  /**
+   * Cierra el modal de detalle y limpia el estado auxiliar.
+   */
+  const handleCloseDetailModal = () => {
+    setSelectedUsuario(null)
+    setDetailError('')
   }
 
   const handleSaveChanges = async () => {
@@ -274,6 +306,14 @@ function Settings({ user, initialTab, onAuthExpired, isAdminUser }) {
                       <span className={getRoleBadgeClass(currentUser.rol)}>{getRoleText(currentUser.rol)}</span>
                     </td>
                     <td>
+                      <div className="settings-inline-actions">
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-info"
+                          onClick={() => handleViewClick(currentUser)}
+                        >
+                          Ver detalle
+                        </button>
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-warning"
@@ -282,6 +322,7 @@ function Settings({ user, initialTab, onAuthExpired, isAdminUser }) {
                       >
                         Editar
                       </button>
+                      </div>
                     </td>
                   </tr>
                 ))
@@ -481,6 +522,84 @@ function Settings({ user, initialTab, onAuthExpired, isAdminUser }) {
                   disabled={isEditLoading}
                 >
                   {isEditLoading ? 'Guardando...' : 'Guardar cambios'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {selectedUsuario && (
+        <div className="modal d-block usuarios-modal-backdrop" style={{ display: 'block' }} tabIndex="-1">
+          <div className="modal-dialog modal-dialog-centered modal-lg">
+            <div className="modal-content usuarios-modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Detalle de usuario</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={handleCloseDetailModal}
+                  aria-label="Cerrar"
+                ></button>
+              </div>
+
+              <div className="modal-body">
+                {isDetailLoading && (
+                  <div className="settings-empty-state" style={{ minHeight: '120px' }}>
+                    <div className="spinner-border text-success" role="status">
+                      <span className="visually-hidden">Cargando...</span>
+                    </div>
+                    <p>Cargando detalle del usuario...</p>
+                  </div>
+                )}
+
+                {!isDetailLoading && (
+                  <>
+                    {detailError && <div className="alert alert-warning">{detailError}</div>}
+
+                    <div className="settings-profile-fields" style={{ width: '100%' }}>
+                      <div>
+                        <label>ID de usuario</label>
+                        <span>{selectedUsuario.idUsuario}</span>
+                      </div>
+
+                      <div>
+                        <label>Nombre</label>
+                        <span>{selectedUsuario.nombre}</span>
+                      </div>
+
+                      <div>
+                        <label>Primer apellido</label>
+                        <span>{selectedUsuario.primerApellido || 'N/A'}</span>
+                      </div>
+
+                      <div>
+                        <label>Segundo apellido</label>
+                        <span>{selectedUsuario.segundoApellido || 'N/A'}</span>
+                      </div>
+
+                      <div>
+                        <label>Correo electronico</label>
+                        <span>{selectedUsuario.email}</span>
+                      </div>
+
+                      <div>
+                        <label>Rol</label>
+                        <span className={getRoleBadgeClass(selectedUsuario.rol)}>{getRoleText(selectedUsuario.rol)}</span>
+                      </div>
+
+                      <div>
+                        <label>Fecha de alta</label>
+                        <span>{formatDate(selectedUsuario.creadoEn || selectedUsuario.fechaAlta)}</span>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+
+              <div className="modal-footer">
+                <button type="button" className="btn btn-outline-secondary" onClick={handleCloseDetailModal}>
+                  Cerrar
                 </button>
               </div>
             </div>

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -215,6 +215,25 @@ export const getAllUsers = async () => {
 }
 
 /**
+ * Obtiene el detalle completo de un usuario por su ID.
+ * Se usa en el panel de administracion para abrir una vista detallada sin
+ * depender solo de los datos resumidos de la tabla.
+ * @param {number} idUsuario - ID del usuario a consultar.
+ * @returns {Promise<object>} Datos completos del usuario.
+ * @throws {Error} Si la petición falla.
+ */
+export const getUserById = async (idUsuario) => {
+  try {
+    const response = await getRequest(`/usuarios/${idUsuario}`)
+    const userData = response?.usuario ?? response
+    return normalizarUsuario(userData)
+  } catch (error) {
+    if (error instanceof Error) throw error
+    throw new Error(String(error), { cause: error })
+  }
+}
+
+/**
  * Actualiza los datos de un usuario (principalmente usado para cambiar rol por admin).
  * @param {number} idUsuario - ID del usuario a actualizar.
  * @param {object} userData - Objeto con los campos a actualizar (nombre, email, rol).


### PR DESCRIPTION
### **Descripción**
Se ha añadido la vista de detalle de usuario reutilizando el endpoint ya existente en backend, y se ha cubierto el flujo con pruebas de integración para validar permisos y acceso administrativo.

### **Rama de trabajo**
`feat/admin-users`

### **Rama destino**
`dev`

### **Tarea**
Viene de la tarea #68

### **Realizado**

- [x]  Añadir acceso a “Ver detalle” de usuario desde el panel admin.
- [x]  Mantener una interfaz clara y responsive en la sección de Settings.
- [x]  Añadir tests de integración para validar permisos admin, listado y detalle de usuarios.