### PR TITLE
feat(backend): completar API y colección Postman v2

### DIFF
--- a/backend/db/migrations/004_add_order_cancellation_date.sql
+++ b/backend/db/migrations/004_add_order_cancellation_date.sql
@@ -1,0 +1,7 @@
+-- Anade trazabilidad para la cancelacion logica de pedidos.
+
+ALTER TABLE pedidos
+MODIFY estado VARCHAR(30) NOT NULL DEFAULT 'pendiente';
+
+ALTER TABLE pedidos
+ADD COLUMN fechaCancelacion DATETIME NULL AFTER estado;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -62,6 +62,7 @@ CREATE TABLE pedidos (
   fecha TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   total DECIMAL(12, 2) NOT NULL DEFAULT 0,
   estado VARCHAR(30) NOT NULL DEFAULT 'pendiente',
+  fechaCancelacion DATETIME NULL,
   direccionEnvio VARCHAR(250) NOT NULL,
   metodoPago VARCHAR(30) NOT NULL,
   idUsuario INT NOT NULL,

--- a/backend/db/seeds.sql
+++ b/backend/db/seeds.sql
@@ -72,10 +72,11 @@ VALUES
   ('Pilar H40 Cerramiento', 'Pilar de hormigon para esquinas y remates en vallas y cerramientos perimetrales.', 98.00, 'pilar', 'Hormigon', 120.00, 40.00, 80.00, 2),
   ('Pilar H40 Ligero', 'Pilar de hormigon compacto para apoyos de cerramientos bajos y delimitaciones temporales.', 72.00, 'pilar', 'Hormigon', 80.00, 40.00, 40.00, 2);
 -- Pedidos
-INSERT INTO pedidos (fecha, total, estado, direccionEnvio, metodoPago, idUsuario)
+INSERT INTO pedidos (fecha, total, estado, fechaCancelacion, direccionEnvio, metodoPago, idUsuario)
 VALUES
-  ('2026-04-20 10:00:00', 1118.00, 'pagado', 'Calle Falsa 123, Madrid', 'tarjeta', 2),
-  ('2026-04-21 12:30:00', 912.00, 'pendiente', 'Av. Central 456, Barcelona', 'paypal', 3);
+  ('2026-04-20 10:00:00', 1118.00, 'pagado', NULL, 'Calle Falsa 123, Madrid', 'tarjeta', 2),
+  ('2026-04-21 12:30:00', 912.00, 'pendiente', NULL, 'Av. Central 456, Barcelona', 'paypal', 3),
+  ('2026-04-22 09:15:00', 42.50, 'cancelado', '2026-04-22 11:00:00', 'Paseo Modular 12, Valencia', 'transferencia', 4);
 
 -- PedidoDetalles
 INSERT INTO pedidoDetalles (idPedido, idProducto, cantidad, precioUnitario)
@@ -84,4 +85,5 @@ VALUES
   (1, 8, 4, 152.00),
   (2, 14, 3, 168.00),
   (2, 20, 3, 112.00),
-  (2, 23, 2, 36.00);
+  (2, 23, 2, 36.00),
+  (3, 1, 1, 42.50);

--- a/backend/postman/squarestruct-mvp.postman_collection.json
+++ b/backend/postman/squarestruct-mvp.postman_collection.json
@@ -1,40 +1,13 @@
 {
   "info": {
-    "_postman_id": "squarestruct-mvp-2026",
-    "name": "SquareStruct MVP - API",
-    "description": "Coleccion oficial para probar el MVP de SquareStruct: health, productos, autenticacion, perfil, gestion admin de usuarios y base de pedidos.",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    "_postman_id": "20dc8ce2-fc6c-439c-bbfe-53a4e4793378",
+    "name": "squarestruct-mvp",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "49087894"
   },
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:3000",
-      "type": "string"
-    },
-    {
-      "key": "token",
-      "value": "",
-      "type": "string"
-    },
-    {
-      "key": "adminToken",
-      "value": "",
-      "type": "string"
-    },
-    {
-      "key": "idUsuario",
-      "value": "1",
-      "type": "string"
-    },
-    {
-      "key": "idProducto",
-      "value": "1",
-      "type": "string"
-    }
-  ],
   "item": [
     {
-      "name": "Estado",
+      "name": "Sistema",
       "item": [
         {
           "name": "Health",
@@ -42,10 +15,12 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/health",
+              "raw": "http://localhost:3000/api/health",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "health"
@@ -55,15 +30,17 @@
           "response": []
         },
         {
-          "name": "Estado de base de datos",
+          "name": "DB status",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/db-status",
+              "raw": "http://localhost:3000/api/db-status",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "db-status"
@@ -78,15 +55,17 @@
       "name": "Productos",
       "item": [
         {
-          "name": "Listar productos",
+          "name": "Obtener productos",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/productos",
+              "raw": "http://localhost:3000/api/productos",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "productos"
@@ -96,19 +75,21 @@
           "response": []
         },
         {
-          "name": "Obtener producto por id",
+          "name": "Obtener producto por ID",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/productos/{{idProducto}}",
+              "raw": "http://localhost:3000/api/productos/28",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "productos",
-                "{{idProducto}}"
+                "28"
               ]
             }
           },
@@ -118,15 +99,10 @@
           "name": "Crear producto",
           "request": {
             "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
+            "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"nombre\": \"Bloque EcoBase\",\n  \"descripcion\": \"Bloque ligero de plastico reciclable para muros modulares.\",\n  \"precio\": 42.5,\n  \"tipo\": \"bloque\",\n  \"material\": \"Plastico reciclable\",\n  \"alto\": 22.7,\n  \"ancho\": 19.7,\n  \"largo\": 39.4,\n  \"idProveedor\": 1\n}",
+              "raw": "{\r\n  \"nombre\": \"TEST Bloque EcoBase\",\r\n  \"descripcion\": \"TEST Bloque ligero de plastico reciclable para primeras hiladas y tramos medios de muro modular.\",\r\n  \"precio\": 42.50,\r\n  \"tipo\": \"bloque\",\r\n  \"material\": \"Plastico reciclable\",\r\n  \"alto\": 22.70,\r\n  \"ancho\": 19.70,\r\n  \"largo\": 39.40,\r\n  \"idProveedor\": 1\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -134,10 +110,12 @@
               }
             },
             "url": {
-              "raw": "{{baseUrl}}/api/productos",
+              "raw": "http://localhost:3000/api/productos",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "productos"
@@ -150,15 +128,10 @@
           "name": "Actualizar producto",
           "request": {
             "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
+            "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"nombre\": \"Bloque EcoBase actualizado\",\n  \"descripcion\": \"Bloque ligero de plastico reciclable para primeras hiladas.\",\n  \"precio\": 45,\n  \"tipo\": \"bloque\",\n  \"material\": \"Plastico reciclable\",\n  \"alto\": 22.7,\n  \"ancho\": 19.7,\n  \"largo\": 39.4,\n  \"idProveedor\": 1\n}",
+              "raw": "{\r\n  \"nombre\": \"TEST Bloque\",\r\n  \"descripcion\": \"TEST\",\r\n  \"precio\": 42.50,\r\n  \"tipo\": \"bloque\",\r\n  \"material\": \"Plastico reciclable\",\r\n  \"alto\": 22.70,\r\n  \"ancho\": 19.60,\r\n  \"largo\": 39.40,\r\n  \"idProveedor\": 1\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -166,14 +139,16 @@
               }
             },
             "url": {
-              "raw": "{{baseUrl}}/api/productos/{{idProducto}}",
+              "raw": "http://localhost:3000/api/productos/26",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "productos",
-                "{{idProducto}}"
+                "26"
               ]
             }
           },
@@ -185,14 +160,16 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/productos/{{idProducto}}",
+              "raw": "http://localhost:3000/api/productos/27",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "productos",
-                "{{idProducto}}"
+                "27"
               ]
             }
           },
@@ -201,10 +178,71 @@
       ]
     },
     {
-      "name": "Autenticacion y perfil",
+      "name": "Usuarios",
       "item": [
         {
-          "name": "Registrar usuario",
+          "name": "Obtener usuarios",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener usuario por ID",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear Usuario / Register",
           "request": {
             "method": "POST",
             "header": [
@@ -215,18 +253,15 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"nombre\": \"Test User\",\n  \"primerApellido\": \"MVP\",\n  \"email\": \"testuser@squarestruct.com\",\n  \"contrasena\": \"12345678\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
+              "raw": "{\n  \"nombre\": \"Test\",\n  \"primerApellido\": \"Admin\",\n  \"segundoApellido\": \"\",\n  \"email\": \"testadmin@squarestruct.com\",\n  \"contrasena\": \"123456\",\n  \"rol\": \"admin\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/api/usuarios/register",
+              "raw": "http://localhost:3000/api/usuarios/register",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "usuarios",
@@ -238,20 +273,6 @@
         },
         {
           "name": "Login usuario",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const data = pm.response.json();",
-                  "if (data.token) {",
-                  "  pm.collectionVariables.set('token', data.token);",
-                  "}"
-                ]
-              }
-            }
-          ],
           "request": {
             "method": "POST",
             "header": [
@@ -262,18 +283,15 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"juan.perez@email.com\",\n  \"contrasena\": \"123456\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
+              "raw": "{\n  \"email\": \"juan.perez@email.com\",\n  \"contrasena\": \"123456\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/api/usuarios/login",
+              "raw": "http://localhost:3000/api/usuarios/login",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "usuarios",
@@ -285,20 +303,6 @@
         },
         {
           "name": "Login admin",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const data = pm.response.json();",
-                  "if (data.token) {",
-                  "  pm.collectionVariables.set('adminToken', data.token);",
-                  "}"
-                ]
-              }
-            }
-          ],
           "request": {
             "method": "POST",
             "header": [
@@ -309,18 +313,15 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"admin@squarestruct.com\",\n  \"contrasena\": \"123456\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
+              "raw": "{\n  \"email\": \"admin@squarestruct.com\",\n  \"contrasena\": \"123456\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/api/usuarios/login",
+              "raw": "http://localhost:3000/api/usuarios/login",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "usuarios",
@@ -331,25 +332,98 @@
           "response": []
         },
         {
-          "name": "Obtener perfil",
+          "name": "Actualizar Usuario",
           "request": {
             "auth": {
               "type": "bearer",
               "bearer": [
                 {
                   "key": "token",
-                  "value": "{{token}}",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
                   "type": "string"
                 }
               ]
             },
-            "method": "GET",
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"nombre\": \"Admin2\",\r\n  \"primerApellido\": \"SquareStruct\",\r\n  \"segundoApellido\": \"\",\r\n  \"email\": \"admin3@squarestruct.com\",\r\n  \"contrasena\": \"$2b$10$hashadmin\",\r\n  \"rol\": \"admin\"\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar Usuario",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/perfil",
+              "raw": "http://localhost:3000/api/usuarios/21",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "21"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Perfil",
+      "item": [
+        {
+          "name": "Obtener perfil",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer <JWT>"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/api/perfil",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
               "path": [
                 "api",
                 "perfil"
@@ -361,176 +435,20 @@
       ]
     },
     {
-      "name": "Usuarios admin",
-      "item": [
-        {
-          "name": "Listar usuarios",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{adminToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/usuarios",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "usuarios"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Obtener usuario por id",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{adminToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/usuarios/{{idUsuario}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "usuarios",
-                "{{idUsuario}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Actualizar rol de usuario",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{adminToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"nombre\": \"Test User\",\n  \"email\": \"testuser@squarestruct.com\",\n  \"rol\": \"usuario\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/usuarios/{{idUsuario}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "usuarios",
-                "{{idUsuario}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Eliminar usuario",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{adminToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "DELETE",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/usuarios/{{idUsuario}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "usuarios",
-                "{{idUsuario}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
       "name": "Pedidos",
       "item": [
         {
-          "name": "Crear pedido",
+          "name": "Obtener pedidos",
           "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{token}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"direccionEnvio\": \"Calle Ejemplo 123, Madrid\",\n  \"metodoPago\": \"tarjeta\",\n  \"productos\": [\n    {\n      \"idProducto\": 1,\n      \"cantidad\": 2\n    }\n  ]\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
+            "method": "GET",
+            "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/pedidos",
+              "raw": "http://localhost:3000/api/pedidos",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
                 "pedidos"
@@ -540,14 +458,14 @@
           "response": []
         },
         {
-          "name": "Listar mis pedidos",
+          "name": "Obtener pedido por ID",
           "request": {
             "auth": {
               "type": "bearer",
               "bearer": [
                 {
                   "key": "token",
-                  "value": "{{token}}",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
                   "type": "string"
                 }
               ]
@@ -555,41 +473,52 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/api/pedidos",
+              "raw": "http://localhost:3000/api/pedidos/1",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
-                "pedidos"
+                "pedidos",
+                "1"
               ]
             }
           },
           "response": []
         },
         {
-          "name": "Crear pedido usando alias orders",
+          "name": "Crear un pedido",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
           "request": {
             "auth": {
               "type": "bearer",
               "bearer": [
                 {
                   "key": "token",
-                  "value": "{{token}}",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
                   "type": "string"
                 }
               ]
             },
             "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
+            "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"direccionEnvio\": \"Calle Ejemplo 123, Madrid\",\n  \"metodoPago\": \"tarjeta\",\n  \"productos\": [\n    {\n      \"idProducto\": 1,\n      \"cantidad\": 1\n    }\n  ]\n}",
+              "raw": "{\r\n  \"direccionEnvio\": \"Calle Test 123, Madrid\",\r\n  \"metodoPago\": \"tarjeta\",\r\n  \"productos\": [\r\n    {\r\n      \"idProducto\": 1,\r\n      \"cantidad\": 1\r\n    }\r\n  ]\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -597,41 +526,15 @@
               }
             },
             "url": {
-              "raw": "{{baseUrl}}/api/orders",
+              "raw": "http://localhost:3000/api/pedidos",
+              "protocol": "http",
               "host": [
-                "{{baseUrl}}"
+                "localhost"
               ],
+              "port": "3000",
               "path": [
                 "api",
-                "orders"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Listar mis pedidos usando alias orders",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{token}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/api/orders",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "orders"
+                "pedidos"
               ]
             }
           },

--- a/backend/postman/squarestruct-v2.postman_collection.json
+++ b/backend/postman/squarestruct-v2.postman_collection.json
@@ -1,0 +1,689 @@
+{
+  "info": {
+    "_postman_id": "2d48f84d-22e3-494a-b24f-2baf4917de37",
+    "name": "squarestruct-v2",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "49087894"
+  },
+  "item": [
+    {
+      "name": "Sistema",
+      "item": [
+        {
+          "name": "Health",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "health"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "DB status",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/db-status",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "db-status"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Productos",
+      "item": [
+        {
+          "name": "Obtener productos",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/productos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener producto por ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/productos/28",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos",
+                "28"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear producto",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"nombre\": \"TEST Bloque EcoBase\",\r\n  \"descripcion\": \"TEST Bloque ligero de plastico reciclable para primeras hiladas y tramos medios de muro modular.\",\r\n  \"precio\": 42.50,\r\n  \"tipo\": \"bloque\",\r\n  \"material\": \"Plastico reciclable\",\r\n  \"alto\": 22.70,\r\n  \"ancho\": 19.70,\r\n  \"largo\": 39.40,\r\n  \"idProveedor\": 1\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/productos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar producto",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"nombre\": \"TEST Bloque\",\r\n  \"descripcion\": \"TEST\",\r\n  \"precio\": 42.50,\r\n  \"tipo\": \"bloque\",\r\n  \"material\": \"Plastico reciclable\",\r\n  \"alto\": 22.70,\r\n  \"ancho\": 19.60,\r\n  \"largo\": 39.40,\r\n  \"idProveedor\": 1\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/productos/26",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos",
+                "26"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar producto",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/productos/27",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos",
+                "27"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Usuarios",
+      "item": [
+        {
+          "name": "Obtener usuarios",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener usuario por ID",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear Usuario / Register",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"nombre\": \"Test\",\n  \"primerApellido\": \"Admin\",\n  \"segundoApellido\": \"\",\n  \"email\": \"testadmin@squarestruct.com\",\n  \"contrasena\": \"123456\",\n  \"rol\": \"admin\"\n}"
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/register",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "register"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Login usuario",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"juan.perez@email.com\",\n  \"contrasena\": \"123456\"\n}"
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/login",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Login admin",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@squarestruct.com\",\n  \"contrasena\": \"123456\"\n}"
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/login",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar Usuario",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"nombre\": \"Admin2\",\r\n  \"primerApellido\": \"SquareStruct\",\r\n  \"segundoApellido\": \"\",\r\n  \"email\": \"admin3@squarestruct.com\",\r\n  \"contrasena\": \"$2b$10$hashadmin\",\r\n  \"rol\": \"admin\"\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar Usuario",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios/21",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios",
+                "21"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Perfil",
+      "item": [
+        {
+          "name": "Obtener perfil",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer <JWT>"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/api/perfil",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "perfil"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Pedidos",
+      "item": [
+        {
+          "name": "Obtener pedidos",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/pedidos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "pedidos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener pedido por ID",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/pedidos/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "pedidos",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear un pedido",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"direccionEnvio\": \"Calle Test 123, Madrid\",\r\n  \"metodoPago\": \"tarjeta\",\r\n  \"productos\": [\r\n    {\r\n      \"idProducto\": 1,\r\n      \"cantidad\": 1\r\n    }\r\n  ]\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/pedidos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "pedidos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar pedido",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZFVzdWFyaW8iOjEsIm5vbWJyZSI6IkFkbWluIiwiZW1haWwiOiJhZG1pbkBzcXVhcmVzdHJ1Y3QuY29tIiwicm9sIjoiYWRtaW4iLCJpYXQiOjE3Nzg2NzIwMjAsImV4cCI6MTc3ODY3OTIyMH0.5eont3InZ7b8e1nsgGDGkqwn4UYKXOp0An9AuRUU-HU",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"motivo\": \"El usuario ha solicitado cancelar el pedido\"\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "PATCH /api/pedidos/1/cancelar",
+              "host": [
+                "PATCH "
+              ],
+              "path": [
+                "api",
+                "pedidos",
+                "1",
+                "cancelar"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Auth / Seguridad",
+      "item": [
+        {
+          "name": "Obtener pedidos - 401 (sin token)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/pedidos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "pedidos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener perfil - 401 (sin token)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/perfil",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "perfil"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener usuario - 401 (sin token)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/api/usuarios",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "usuarios"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear producto - 401 (sin token)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"nombre\": \"TEST Bloque EcoBase\",\r\n  \"descripcion\": \"TEST Bloque ligero de plastico reciclable para primeras hiladas y tramos medios de muro modular.\",\r\n  \"precio\": 42.50,\r\n  \"tipo\": \"bloque\",\r\n  \"material\": \"Plastico reciclable\",\r\n  \"alto\": 22.70,\r\n  \"ancho\": 19.70,\r\n  \"largo\": 39.40,\r\n  \"idProveedor\": 1\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/api/productos",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "api",
+                "productos"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/controllers/pedidosController.js
+++ b/backend/src/controllers/pedidosController.js
@@ -106,7 +106,7 @@ export const listarPedidosUsuario = async (req, res) => {
     const idUsuario = req.user.idUsuario || req.user.id;
 
     const [pedidos] = await db.query(
-      `SELECT idPedido, fecha, total, estado, direccionEnvio, metodoPago
+      `SELECT idPedido, fecha, total, estado, fechaCancelacion, direccionEnvio, metodoPago
        FROM pedidos
        WHERE idUsuario = ?
        ORDER BY fecha DESC`,
@@ -117,6 +117,102 @@ export const listarPedidosUsuario = async (req, res) => {
   } catch (error) {
     res.status(500).json({
       error: 'Error al obtener los pedidos'
+    });
+  }
+};
+
+export const obtenerPedidoById = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const idUsuario = req.user.idUsuario || req.user.id;
+    const esAdmin = req.user?.rol?.toLowerCase() === 'admin';
+
+    const [pedidos] = await db.query(
+      `SELECT idPedido, fecha, total, estado, fechaCancelacion, direccionEnvio, metodoPago, idUsuario
+       FROM pedidos
+       WHERE idPedido = ? ${esAdmin ? '' : 'AND idUsuario = ?'}`,
+      esAdmin ? [id] : [id, idUsuario]
+    );
+
+    if (pedidos.length === 0) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+
+    const [detalles] = await db.query(
+      `SELECT
+        pd.idProducto,
+        pd.cantidad,
+        pd.precioUnitario,
+        p.nombre
+       FROM pedidoDetalles pd
+       JOIN productos p ON pd.idProducto = p.idProducto
+       WHERE pd.idPedido = ?`,
+      [id]
+    );
+
+    res.json({
+      ...pedidos[0],
+      productos: detalles
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Error al obtener el pedido',
+      detalle: error.message
+    });
+  }
+};
+
+export const cancelarPedido = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const idUsuario = req.user.idUsuario || req.user.id;
+    const esAdmin = req.user?.rol?.toLowerCase() === 'admin';
+
+    const [pedidos] = await db.query(
+      `SELECT idPedido, estado, idUsuario
+       FROM pedidos
+       WHERE idPedido = ?`,
+      [id]
+    );
+
+    if (pedidos.length === 0) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+
+    const pedido = pedidos[0];
+
+    if (!esAdmin && Number(pedido.idUsuario) !== Number(idUsuario)) {
+      return res.status(403).json({ error: 'No puedes cancelar este pedido' });
+    }
+
+    if (pedido.estado === 'cancelado') {
+      return res.status(409).json({ error: 'El pedido ya esta cancelado' });
+    }
+
+    if (['enviado', 'entregado'].includes(pedido.estado)) {
+      return res.status(409).json({
+        error: 'No se puede cancelar un pedido completado o enviado'
+      });
+    }
+
+    await db.query(
+      `UPDATE pedidos
+       SET estado = 'cancelado', fechaCancelacion = NOW()
+       WHERE idPedido = ?`,
+      [id]
+    );
+
+    res.json({
+      message: 'Pedido cancelado correctamente',
+      pedido: {
+        idPedido: Number(id),
+        estado: 'cancelado'
+      }
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Error al cancelar el pedido',
+      detalle: error.message
     });
   }
 };

--- a/backend/src/middlewares/auth.js
+++ b/backend/src/middlewares/auth.js
@@ -1,8 +1,8 @@
 import jwt from 'jsonwebtoken';
 
-// Middleware para verificar JWT y añadir el usuario autenticado a req.user
+// Middleware para verificar JWT y anadir el usuario autenticado a req.user.
 export default function authMiddleware(req, res, next) {
-  const authHeader = req.headers['authorization'];
+  const authHeader = req.headers.authorization;
 
   // Formato esperado: "Bearer TOKEN"
   const token = authHeader && authHeader.split(' ')[1];
@@ -20,11 +20,10 @@ export default function authMiddleware(req, res, next) {
   jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
     if (err) {
       return res.status(403).json({
-        error: 'Token inválido'
+        error: 'Token invalido'
       });
     }
 
-    // Guardamos el usuario en la request
     req.user = user;
 
     next();

--- a/backend/src/routes/pedidos.js
+++ b/backend/src/routes/pedidos.js
@@ -3,12 +3,16 @@ import express from 'express';
 import authMiddleware from '../middlewares/auth.js';
 import {
   crearPedido,
-  listarPedidosUsuario
+  listarPedidosUsuario,
+  obtenerPedidoById,
+  cancelarPedido
 } from '../controllers/pedidosController.js';
 
 const router = express.Router();
 
 router.get('/', authMiddleware, listarPedidosUsuario);
 router.post('/', authMiddleware, crearPedido);
+router.get('/:id', authMiddleware, obtenerPedidoById);
+router.patch('/:id/cancelar', authMiddleware, cancelarPedido);
 
 export default router;

--- a/backend/src/routes/productos.js
+++ b/backend/src/routes/productos.js
@@ -7,14 +7,16 @@ import {
   actualizarProducto,
   eliminarProducto
 } from '../controllers/productosController.js';
+import adminMiddleware from '../middlewares/admin.js';
+import authMiddleware from '../middlewares/auth.js';
 import { validarProducto } from '../middlewares/validacionProducto.js';
 
 const router = express.Router();
 
 router.get('/', getProductos);
 router.get('/:id', getProductoById);
-router.post('/', validarProducto, crearProducto);
-router.put('/:id', validarProducto, actualizarProducto);
-router.delete('/:id', eliminarProducto);
+router.post('/', authMiddleware, adminMiddleware, validarProducto, crearProducto);
+router.put('/:id', authMiddleware, adminMiddleware, validarProducto, actualizarProducto);
+router.delete('/:id', authMiddleware, adminMiddleware, eliminarProducto);
 
 export default router;

--- a/backend/tests/integration/productos-pedidos.test.js
+++ b/backend/tests/integration/productos-pedidos.test.js
@@ -3,9 +3,24 @@ import app, { db } from '../../src/app.js';
 
 describe('Productos y pedidos', () => {
   const email = `pedido${Date.now()}@mail.com`;
+  const otherEmail = `pedido-otro${Date.now()}@mail.com`;
+  const adminEmail = `admin-productos${Date.now()}@mail.com`;
   const password = '12345678';
   let token;
+  let otherToken;
+  let adminToken;
   let idProducto;
+  let idPedido;
+
+  beforeAll(async () => {
+    try {
+      await db.query('ALTER TABLE pedidos ADD COLUMN fechaCancelacion DATETIME NULL AFTER estado');
+    } catch (error) {
+      if (error.code !== 'ER_DUP_FIELDNAME') {
+        throw error;
+      }
+    }
+  });
 
   afterAll(async () => {
     await db.end();
@@ -21,6 +36,70 @@ describe('Productos y pedidos', () => {
     expect(res.body[0].nombre).toBeDefined();
 
     idProducto = res.body[0].idProducto;
+  });
+
+  it('prepara un admin autenticado para gestionar productos', async () => {
+    await db.query(
+      `INSERT INTO usuarios (nombre, primerApellido, email, contrasena, rol)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+        'Admin Productos',
+        'Test',
+        adminEmail,
+        '$2b$10$uDPwExnvB1b.4fDtKNOKZOx.4BmAODWoLc23EtZZOa6IPljXf3cjW',
+        'admin'
+      ]
+    );
+
+    const res = await request(app)
+      .post('/api/usuarios/login')
+      .send({
+        email: adminEmail,
+        contrasena: '123456'
+      });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+    adminToken = res.body.token;
+  });
+
+  it('POST /api/productos debe rechazar creacion sin token', async () => {
+    const res = await request(app)
+      .post('/api/productos')
+      .send({
+        nombre: 'TEST Bloque EcoBase',
+        descripcion: 'Bloque creado desde test de integracion.',
+        precio: 42.5,
+        tipo: 'bloque',
+        material: 'Plastico reciclable',
+        alto: 22.7,
+        ancho: 19.7,
+        largo: 39.4,
+        idProveedor: 1
+      });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('POST /api/productos debe permitir creacion con token admin', async () => {
+    const res = await request(app)
+      .post('/api/productos')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        nombre: 'TEST Bloque EcoBase',
+        descripcion: 'Bloque creado desde test de integracion.',
+        precio: 42.5,
+        tipo: 'bloque',
+        material: 'Plastico reciclable',
+        alto: 22.7,
+        ancho: 19.7,
+        largo: 39.4,
+        idProveedor: 1
+      });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.idProducto).toBeDefined();
+    idProducto = res.body.idProducto;
   });
 
   it('prepara un usuario autenticado para probar pedidos', async () => {
@@ -42,6 +121,25 @@ describe('Productos y pedidos', () => {
     expect(loginRes.statusCode).toBe(200);
     expect(loginRes.body.token).toBeDefined();
     token = loginRes.body.token;
+
+    const otherRegisterRes = await request(app)
+      .post('/api/usuarios/register')
+      .send({
+        nombre: 'Otro',
+        primerApellido: 'Pedido',
+        email: otherEmail,
+        contrasena: password
+      });
+
+    expect(otherRegisterRes.statusCode).toBe(201);
+
+    const otherLoginRes = await request(app)
+      .post('/api/usuarios/login')
+      .send({ email: otherEmail, contrasena: password });
+
+    expect(otherLoginRes.statusCode).toBe(200);
+    expect(otherLoginRes.body.token).toBeDefined();
+    otherToken = otherLoginRes.body.token;
   });
 
   it('GET /api/pedidos debe rechazar peticiones sin token', async () => {
@@ -78,5 +176,114 @@ describe('Productos y pedidos', () => {
     expect(res.body.mensaje).toBe('Pedido creado correctamente');
     expect(res.body.idPedido).toBeDefined();
     expect(Number(res.body.total)).toBeGreaterThan(0);
+
+    idPedido = res.body.idPedido;
+  });
+
+  it('GET /api/pedidos/:id debe devolver un pedido concreto con token', async () => {
+    const res = await request(app)
+      .get(`/api/pedidos/${idPedido}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.idPedido).toBe(idPedido);
+    expect(Array.isArray(res.body.productos)).toBe(true);
+  });
+
+  it('PATCH /api/pedidos/:id/cancelar debe cancelar un pedido con token', async () => {
+    const res = await request(app)
+      .patch(`/api/pedidos/${idPedido}/cancelar`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ motivo: 'Cancelado desde test de integracion' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Pedido cancelado correctamente');
+    expect(res.body.pedido).toEqual({
+      idPedido,
+      estado: 'cancelado'
+    });
+  });
+
+  it('PATCH /api/pedidos/:id/cancelar debe impedir cancelar dos veces', async () => {
+    const res = await request(app)
+      .patch(`/api/pedidos/${idPedido}/cancelar`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body.error).toBe('El pedido ya esta cancelado');
+  });
+
+  it('PATCH /api/pedidos/:id/cancelar debe impedir cancelar pedidos enviados', async () => {
+    const pedidoRes = await request(app)
+      .post('/api/pedidos')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        direccionEnvio: 'Calle Envio 123, Madrid',
+        metodoPago: 'tarjeta',
+        productos: [
+          {
+            idProducto,
+            cantidad: 1
+          }
+        ]
+      });
+
+    await db.query('UPDATE pedidos SET estado = ? WHERE idPedido = ?', ['enviado', pedidoRes.body.idPedido]);
+
+    const res = await request(app)
+      .patch(`/api/pedidos/${pedidoRes.body.idPedido}/cancelar`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body.error).toBe('No se puede cancelar un pedido completado o enviado');
+  });
+
+  it('PATCH /api/pedidos/:id/cancelar debe rechazar usuarios que no son propietarios', async () => {
+    const pedidoRes = await request(app)
+      .post('/api/pedidos')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        direccionEnvio: 'Calle Propietario 123, Madrid',
+        metodoPago: 'tarjeta',
+        productos: [
+          {
+            idProducto,
+            cantidad: 1
+          }
+        ]
+      });
+
+    const res = await request(app)
+      .patch(`/api/pedidos/${pedidoRes.body.idPedido}/cancelar`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toBe('No puedes cancelar este pedido');
+  });
+
+  it('PATCH /api/pedidos/:id/cancelar debe permitir cancelar a un admin', async () => {
+    const pedidoRes = await request(app)
+      .post('/api/pedidos')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        direccionEnvio: 'Calle Admin 123, Madrid',
+        metodoPago: 'tarjeta',
+        productos: [
+          {
+            idProducto,
+            cantidad: 1
+          }
+        ]
+      });
+
+    const res = await request(app)
+      .patch(`/api/pedidos/${pedidoRes.body.idPedido}/cancelar`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.pedido).toEqual({
+      idPedido: pedidoRes.body.idPedido,
+      estado: 'cancelado'
+    });
   });
 });


### PR DESCRIPTION
## Resumen

Completa los flujos backend necesarios para validar la colección Postman v2 y las pruebas manuales del MVP.

## Cambios

- Añadida protección admin para crear, editar y eliminar productos.
- Añadida cancelación lógica de pedidos con `PATCH /api/pedidos/:id/cancelar`.
- Añadida consulta de pedido por id.
- Añadida trazabilidad de cancelación con `fechaCancelacion`.
- Actualizados `schema.sql`, migración y seeds.
- Actualizadas colecciones Postman MVP y v2.
- Ampliados tests de integración de productos y pedidos.

## Validación

- [x] `npm.cmd run test:integration`
- [x] Productos públicos para consulta.
- [x] Escritura de productos protegida por admin.
- [x] Pedidos protegidos por JWT.
- [x] Cancelación lógica sin borrar pedidos.

## Issue

Closes #82
